### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/hoangmyit/a4da4142-f6c4-4b1e-ad00-239e2a6cad10/f145b943-3e79-4d66-9f9f-96cdcec74377/_apis/work/boardbadge/fbc71ffb-4073-465d-92fa-c5203ccff40e)](https://dev.azure.com/hoangmyit/a4da4142-f6c4-4b1e-ad00-239e2a6cad10/_boards/board/t/f145b943-3e79-4d66-9f9f-96cdcec74377/Microsoft.RequirementCategory)
 # ExpenditureManagement


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hoangmyit/a4da4142-f6c4-4b1e-ad00-239e2a6cad10/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.